### PR TITLE
fill chat window to available space

### DIFF
--- a/src/display/controllers/IrishKeyboard/IrishKeyboard.tsx
+++ b/src/display/controllers/IrishKeyboard/IrishKeyboard.tsx
@@ -122,7 +122,7 @@ const IrishKeyboard = () => {
   };
 
   return (
-    <Box>
+    <Box className="flex-fill-below">
       <CenteredFlexBox p={1} sx={{ position: 'relative' }}>
         <BatBox width={'100%'} padding={0.5}>
           <Grid container py={1} height={isMobile() ? 56 : 70}>

--- a/src/display/pages/Chat/Chat.tsx
+++ b/src/display/pages/Chat/Chat.tsx
@@ -44,7 +44,7 @@ function flexFillHeight() {
   const rectAbove = elAbove.getBoundingClientRect();
   const top = rectAbove.bottom + window.scrollY;
   const elBelow = document.querySelector('.flex-fill-below');
-  let roomBelow = 102; // guess height of
+  let roomBelow = 102; // guess height of IrishKeyboard in case it's not yet mounted
   if (elBelow) {
     const rectBelow = elBelow.getBoundingClientRect();
     roomBelow = rectBelow.height;
@@ -52,19 +52,24 @@ function flexFillHeight() {
 
   const pxHeight = window.innerHeight - top - roomBelow; // rectBelow.height;
   if (pxHeight < 100) return '100px';
+  if (pxHeight > 1000) return '1000px';
   return pxHeight + 'px';
 }
 
 function chatWindowFillSpaceEffect() {
   window.addEventListener('resize', handleResize);
   handleResize();
+  window.addEventListener('orientationchange', handleResize);
   return handleResizeDestructor;
 
   function handleResize() {
     const chatMain = document.querySelector('.flex-fill-main');
-    if (chatMain) {
+    if (chatMain instanceof HTMLElement) {
       chatMain.style.height = flexFillHeight();
-      console.log(chatMain);
+    } else {
+      console.error(
+        'failed to update height of chat window, selected element is not a HTMLElement',
+      );
     }
   }
 
@@ -203,7 +208,7 @@ function Chat() {
           </Box>
         </BatBox>
       </CenteredFlexBox>
-      {activeChat !== undefined && <IrishKeyboard className="flex-fill-below" />}
+      {activeChat !== undefined && <IrishKeyboard />}
     </Box>
   );
 }

--- a/src/display/pages/Chat/Chat.tsx
+++ b/src/display/pages/Chat/Chat.tsx
@@ -22,7 +22,6 @@ import { useUpdatePoints } from '@/hooks';
 import { usePopulateChats } from '@/hooks';
 import useGenerateNextQuestion from '@/hooks/questions/useGenerateNextQuestion';
 import useAdjacencyPairLogic from '@/hooks/useAdjacencyPairLogic';
-import { getChatHeight } from '@/routes/Pages/utils';
 import { getAdjacencyPairs, getQuestions } from '@/services/supabase';
 import { useAdjacencyPairs, useReceivedAdjacencyPairHistory } from '@/store/adjacencyPairs';
 import { currentAdjacencyPairState } from '@/store/adjacencyPairs';
@@ -37,6 +36,42 @@ import { useBatTyping, useTaNilInputChoice } from '@/store/textInput';
 
 import anonImg from '/assets/images/anon-avatar.png';
 import robotImg from '/assets/images/robot.png';
+
+// calculate the height of the chat area to fill the entire screen
+function flexFillHeight() {
+  const elAbove = document.querySelector('.flex-fill-above');
+  if (!elAbove) return '60vh';
+  const rectAbove = elAbove.getBoundingClientRect();
+  const top = rectAbove.bottom + window.scrollY;
+  const elBelow = document.querySelector('.flex-fill-below');
+  let roomBelow = 102; // guess height of
+  if (elBelow) {
+    const rectBelow = elBelow.getBoundingClientRect();
+    roomBelow = rectBelow.height;
+  }
+
+  const pxHeight = window.innerHeight - top - roomBelow; // rectBelow.height;
+  if (pxHeight < 100) return '100px';
+  return pxHeight + 'px';
+}
+
+function chatWindowFillSpaceEffect() {
+  window.addEventListener('resize', handleResize);
+  handleResize();
+  return handleResizeDestructor;
+
+  function handleResize() {
+    const chatMain = document.querySelector('.flex-fill-main');
+    if (chatMain) {
+      chatMain.style.height = flexFillHeight();
+      console.log(chatMain);
+    }
+  }
+
+  function handleResizeDestructor() {
+    window.removeEventListener('resize', handleResize);
+  }
+}
 
 function Chat() {
   const { profile } = useProfile();
@@ -96,6 +131,8 @@ function Chat() {
     }
   }, [session, activeChat, chats]);
 
+  useEffect(chatWindowFillSpaceEffect);
+
   useEffect(() => {
     if (session !== null && activeChat !== undefined && receivedAdjacencyPairHistory) {
       adjacencyPairLogic();
@@ -118,20 +155,20 @@ function Chat() {
   }, [firstLoad, receivedAdjacencyPairHistory]);
 
   return (
-    <Box sx={{ backgroundColor: 'background', height: '50px' }}>
+    <Box sx={{ backgroundColor: 'background' }}>
       <Meta title="Chat" />
 
       <MessageInputButtons vis={taNilInputChoice ? 'visible' : 'hidden'} />
 
-      <CenteredFlexBox p={1}>
+      <CenteredFlexBox className="flex-fill-above" p={1}>
         <EndChatStats />
         <BatBox width={'100%'} padding={0.5}>
           <PointsDisplay />
         </BatBox>
       </CenteredFlexBox>
-      <CenteredFlexBox px={1}>
+      <CenteredFlexBox className="flex-fill-main" px={1} sx={{ height: flexFillHeight() }}>
         <BatBox width={'100%'} backgroundColor={'background.default'} padding={0}>
-          <Box px={0.6} py={0.5} sx={{ height: getChatHeight() }}>
+          <Box px={0.6} py={0.5} sx={{ height: '100%' }}>
             <ChatContainer>
               <MessageList
                 typingIndicator={
@@ -166,7 +203,7 @@ function Chat() {
           </Box>
         </BatBox>
       </CenteredFlexBox>
-      {activeChat !== undefined && <IrishKeyboard />}
+      {activeChat !== undefined && <IrishKeyboard className="flex-fill-below" />}
     </Box>
   );
 }

--- a/src/routes/Pages/utils.ts
+++ b/src/routes/Pages/utils.ts
@@ -5,8 +5,4 @@ function getPageHeight(theme: Theme) {
   return `calc(100vh - ${topSpacing}px)`;
 }
 
-function getChatHeight() {
-  return `calc(100vh - 530px)`;
-}
-
-export { getPageHeight, getChatHeight };
+export { getPageHeight };


### PR DESCRIPTION
related issue: https://github.com/phonlab-tcd/An-Scealai/issues/533

The aim of this PR is to make the chat window on fill the available space so that it is more likely to work on weirdly sized screens (and we expect weirdly sized screens when using bat-mirialta as an iframe for An-Scéalaí!).

Behaviour on PR branch (https://github.com/Neimhin/bat-mirialta/tree/neimhin/chat-sizing):
![pr-chat-sizing](https://github.com/phonlab-tcd/bat-mirialta/assets/63593371/49fd79dd-fdc3-4ea1-8e19-2b855ea62dfa)

Behaviour on main branch (https://github.com/phonlab-tcd/bat-mirialta/tree/main):
![main-chat-sizing](https://github.com/phonlab-tcd/bat-mirialta/assets/63593371/80307a97-bd1b-42ed-8d62-c11714f96d07)

Possible issues:
- [ ] this code is **not** well encapsulated because of the use of class names "flex-fill-above", "flex-fill-main", "flex-fill-below", open to suggestions on how to improve encapsulation
- [ ] liberal use of `document` and `window` here which may be a code smell?
- [ ] the chat window will fill all available vertical height, which may not be appropriated on a big laptop monitor in portrait orientation etc.

